### PR TITLE
Add optional UseDays UseHours to the spawn tickets

### DIFF
--- a/GUI/layouts/SpawnSelectMenu.layout
+++ b/GUI/layouts/SpawnSelectMenu.layout
@@ -82,8 +82,8 @@ FrameWidgetClass SpawnSelectRoot {
    visible 0
    ignorepointer 1
    color 0.102 0.0784 0.0784 1
-   position -0.11404 0.02342
-   size 0.47433 0.54792
+   position -0.114 0.0334
+   size 0.4743 0.65
    halign center_ref
    valign center_ref
    hexactpos 0
@@ -129,8 +129,8 @@ FrameWidgetClass SpawnSelectRoot {
      vexactsize 0
     }
     CheckBoxWidgetClass CheckBoxIsTicket {
-     position 0.00155 -0.03414
-     size 0.36521 0.06293
+     position 0.0016 -0.1441
+     size 0.3652 0.0429
      halign center_ref
      valign center_ref
      hexactpos 0
@@ -142,8 +142,8 @@ FrameWidgetClass SpawnSelectRoot {
     PanelWidgetClass PanelNewSpawn {
      visible 1
      ignorepointer 1
-     position 0.00502 0.16485
-     size 0.98174 0.23328
+     position 0.005 0.1249
+     size 0.9817 0.1933
      hexactpos 0
      vexactpos 0
      hexactsize 0
@@ -269,8 +269,8 @@ FrameWidgetClass SpawnSelectRoot {
     PanelWidgetClass PanelInsertAsTicket {
      visible 0
      ignorepointer 1
-     position 0.00822 0.53304
-     size 0.98174 0.34453
+     position 0.0082 0.393
+     size 0.9817 0.4745
      hexactpos 0
      vexactpos 0
      hexactsize 0
@@ -278,8 +278,8 @@ FrameWidgetClass SpawnSelectRoot {
      {
       EditBoxWidgetClass SpawnPosXEdit0 {
        color 0.1569 0.2745 0.6235 1
-       position 0.01037 0.25051
-       size 0.31999 0.19734
+       position 0.0104 0.1605
+       size 0.32 0.1173
        hexactpos 0
        vexactpos 0
        hexactsize 0
@@ -289,8 +289,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       TextWidgetClass TextWidget3 {
        ignorepointer 1
-       position 0.00857 0.06252
-       size 0.32138 0.16647
+       position 0.0086 0.0125
+       size 0.3214 0.1265
        hexactpos 0
        vexactpos 0
        hexactsize 0
@@ -301,8 +301,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       EditBoxWidgetClass SpawnPosYEdit0 {
        color 0.1569 0.2745 0.6235 1
-       position 0.34137 0.24938
-       size 0.31998 0.19734
+       position 0.3414 0.1605
+       size 0.32 0.1173
        hexactpos 0
        vexactpos 0
        hexactsize 0
@@ -312,8 +312,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       TextWidgetClass TextWidget4 {
        ignorepointer 1
-       position 0.33957 0.06138
-       size 0.32138 0.16647
+       position 0.3396 0.0125
+       size 0.3214 0.1265
        hexactpos 0
        vexactpos 0
        hexactsize 0
@@ -324,8 +324,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       EditBoxWidgetClass SpawnPosZEdit0 {
        color 0.1569 0.2745 0.6235 1
-       position 0.66995 0.24839
-       size 0.31998 0.19734
+       position 0.67 0.1605
+       size 0.32 0.1173
        hexactpos 0
        vexactpos 0
        hexactsize 0
@@ -335,8 +335,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       TextWidgetClass TextWidget5 {
        ignorepointer 1
-       position 0.66815 0.0604
-       size 0.32138 0.16647
+       position 0.6682 0.0125
+       size 0.3214 0.1265
        hexactpos 0
        vexactpos 0
        hexactsize 0
@@ -347,8 +347,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       EditBoxWidgetClass UsePosClassName {
        color 0.1569 0.2745 0.6235 1
-       position 0.06173 0.03315
-       size 0.39566 0.19734
+       position 0.0617 0.1026
+       size 0.3957 0.1173
        halign center_ref
        valign bottom_ref
        hexactpos 0
@@ -360,8 +360,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       TextWidgetClass TextWidget6 {
        ignorepointer 1
-       position 0.0608 0.26529
-       size 0.39739 0.16647
+       position 0.0608 0.2353
+       size 0.3974 0.1265
        halign center_ref
        valign bottom_ref
        hexactpos 0
@@ -374,8 +374,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       TextWidgetClass TextWidget7 {
        ignorepointer 1
-       position -0.31551 0.26477
-       size 0.33493 0.16647
+       position -0.3155 0.2353
+       size 0.3349 0.1265
        halign center_ref
        valign bottom_ref
        hexactpos 0
@@ -388,8 +388,8 @@ FrameWidgetClass SpawnSelectRoot {
       }
       EditBoxWidgetClass UsePosRadiusEdit {
        color 0.1569 0.2745 0.6235 1
-       position -0.31474 0.03263
-       size 0.33348 0.19734
+       position -0.3147 0.1026
+       size 0.3335 0.1173
        halign center_ref
        valign bottom_ref
        hexactpos 0
@@ -400,8 +400,8 @@ FrameWidgetClass SpawnSelectRoot {
        font "gui/fonts/metron22"
       }
       CheckBoxWidgetClass CheckUseItemInHands {
-       position 0.38019 0.37115
-       size 0.23128 0.1537
+       position 0.3802 0.3411
+       size 0.2313 0.1037
        halign center_ref
        valign center_ref
        hexactpos 0
@@ -410,12 +410,66 @@ FrameWidgetClass SpawnSelectRoot {
        vexactsize 0
        text "Use Item in Hands?"
       }
+      EditBoxWidgetClass UseHours {
+       color 0.1569 0.2745 0.6235 1
+       position 0.2517 0.3926
+       size 0.48 0.1173
+       halign center_ref
+       valign bottom_ref
+       hexactpos 0
+       vexactpos 0
+       hexactsize 0
+       vexactsize 0
+       style DefaultBorder
+       font "gui/fonts/metron22"
+      }
+      TextWidgetClass TextWidget10 {
+       ignorepointer 1
+       position 0.2517 0.5253
+       size 0.48 0.1265
+       halign center_ref
+       valign bottom_ref
+       hexactpos 0
+       vexactpos 0
+       hexactsize 0
+       vexactsize 0
+       text "Use Hours"
+       font "gui/fonts/metron22"
+       "text halign" center
+      }
+      TextWidgetClass TextWidget11 {
+       ignorepointer 1
+       position -0.2455 0.5253
+       size 0.48 0.1265
+       halign center_ref
+       valign bottom_ref
+       hexactpos 0
+       vexactpos 0
+       hexactsize 0
+       vexactsize 0
+       text "Use Days"
+       font "gui/fonts/metron22"
+       "text halign" center
+      }
+      EditBoxWidgetClass UseDays {
+       color 0.1569 0.2745 0.6235 1
+       position -0.2455 0.3926
+       size 0.48 0.1173
+       halign center_ref
+       valign bottom_ref
+       hexactpos 0
+       vexactpos 0
+       hexactsize 0
+       vexactsize 0
+       style DefaultBorder
+       font "gui/fonts/metron22"
+      }
      }
     }
     ButtonWidgetClass BtnSendNewSpawnToServer {
      color 0.1569 0.2745 0.6235 1
-     position 0.68844 0.9043
-     size 0.2989 0.08035
+     position 0.6884 0.9243
+     size 0.2989 0.0603
      hexactpos 0
      vexactpos 0
      hexactsize 0
@@ -426,8 +480,8 @@ FrameWidgetClass SpawnSelectRoot {
     }
     ButtonWidgetClass BtnTutorial {
      color 0.1569 0.2745 0.6235 1
-     position 0.00886 0.90408
-     size 0.2989 0.08035
+     position 0.0089 0.9243
+     size 0.2989 0.0603
      hexactpos 0
      vexactpos 0
      hexactsize 0

--- a/scripts/3_Game/Objects/spawnticketobject.c
+++ b/scripts/3_Game/Objects/spawnticketobject.c
@@ -2,16 +2,20 @@ class SpawnTicketObject
 {
     protected string                                m_classname;
     protected string                                m_ID;
+    protected string                                m_UseDaysUTC;
+    protected string                                m_UseHoursUTC;
     protected vector 				                m_UsePosition;
 	protected float 				                m_UseRadius;
     protected ref array <ref SpawnLocationObject>   m_PossibleSpawn;
 
-    void SpawnTicketObject(string Classname, string Id, vector UsePosition, float UseRadius, ref array<ref SpawnLocationObject> Spawn)
+    void SpawnTicketObject(string Classname, string Id, vector UsePosition, float UseRadius, ref array<ref SpawnLocationObject> Spawn, string UseDaysUTC, string UseHoursUTC)
     {
         m_classname = Classname;
         m_ID = Id;
         m_PossibleSpawn = Spawn;
         m_UsePosition = UsePosition;
+        m_UseDaysUTC = UseDaysUTC;
+        m_UseHoursUTC = UseHoursUTC;
         m_UseRadius = UseRadius;
     }
 
@@ -25,6 +29,66 @@ class SpawnTicketObject
         return m_ID;
     }
 
+	bool IsInUseTime()
+	{
+		if((m_UseDaysUTC.Length() == 0 && m_UseHoursUTC.Length() == 0))
+		{
+			return true;
+		}
+		
+		int /*year, month, day, hour, minute, */utcHour, utcMinute, utcSecond, i, timeUTC;
+		GetHourMinuteSecondUTC(utcHour, utcMinute, utcSecond);
+		//GetGame().GetWorld().GetDate( year, month, day, hour, minute );
+		timeUTC = (utcHour*60)+utcMinute;
+		
+		// m_UseDaysUTC "1 2 3 4 5 6 7"
+		if(m_UseDaysUTC.Length() > 0)
+		{
+			int utcWeekDay = GetDayOfWeek();
+			if (m_UseDaysUTC.IndexOf(utcWeekDay.ToString()) == -1) {
+				return false;
+			}
+		}
+		// m_UseHoursUTC "8 9-10 11-11:30 12:15"
+		if(m_UseHoursUTC.Length() > 0)
+		{
+			bool timeMatch = false;
+			int ticketTimeMin, ticketTimeMax;
+			TStringArray hours = new TStringArray;
+			m_UseHoursUTC.Split( " ", hours );
+			for ( i = 0; i < hours.Count(); i++ )
+			{
+				if(hours.Get(i).IndexOf( "-" ) != -1)
+				{
+					TStringArray hourRange = new TStringArray;
+					hours.Get(i).Split( "-", hourRange );
+					ticketTimeMin = ConvertToMinutes(hourRange.Get(0));
+					ticketTimeMax = ConvertToMinutes(hourRange.Get(1));
+					if(timeUTC >= ticketTimeMin && timeUTC <= ticketTimeMax)
+					{
+						timeMatch = true;
+						break;
+					}
+				}
+				else
+				{
+					int ticketTime = ConvertToMinutes(hours.Get(i));
+					if(ticketTime == timeUTC)
+					{
+						timeMatch = true;
+						break;
+					}
+				}
+			}
+			if(!timeMatch)
+			{
+				return false;
+			}
+		}
+		
+		return true;
+	}
+	
     bool IsInUseRange(vector Position)
     {
         if(m_UsePosition && m_UseRadius && Position)
@@ -37,6 +101,16 @@ class SpawnTicketObject
             return false;
         }
         return true;
+    }
+
+    string GetUseDaysUTC()
+    {
+        return m_UseDaysUTC;
+    }
+
+    string GetUseHoursUTC()
+    {
+        return m_UseHoursUTC;
     }
 
     vector GetUsePostion()
@@ -53,4 +127,54 @@ class SpawnTicketObject
     {
         return m_PossibleSpawn;
     }
+	
+	// Converts string formatted hour[:minute] to minutes
+	// e.g. "1" => 60, "3:15" => 195
+	private int ConvertToMinutes(string hoursStr)
+	{
+		int hours, minutes = 0;
+		if(hoursStr.IndexOf( ":" ) != -1)
+		{
+			TStringArray hoursMinutes = new TStringArray;
+			hoursStr.Split( ":", hoursMinutes );
+			hours = hoursMinutes.Get(0).ToInt();
+			minutes = hoursMinutes.Get(1).ToInt();
+		}
+		else
+		{
+			hours = hoursStr.ToInt();
+		}
+		return (hours*60) + minutes;
+	}
+	
+	// Returns today's number of the day in a week.
+	private int GetDayOfWeek()
+	{
+		int c, y, m, d;
+		GetYearMonthDayUTC(y, m, d);
+
+		c = y/100;
+		if (m < 3)
+		{
+			y -= 1;
+			m += 10;
+		}
+		else m -= 2;
+		
+		int dowraw = (d + Math.Floor(2.6 * m - 0.2) - 2 * c + y + Math.Floor(y / 4) + Math.Floor(c / 4));
+
+		// Here we get the remainder of dowraw divided by 7.
+		// Basically, should have been just "dowraw % 7", but DayZ says it doesn't know the % operator,
+		// Yet, it is definitely used in enscript though. Odd stuff.
+		int dow = Math.Floor(dowraw / 7);
+		dow = dow * 7;
+		dow = dowraw - dow;
+		if (dow == 0) dow = 7;
+
+		// Move days for Mon-Sun week.
+		dow -= 1;
+		if (dow == 0) dow = 7;
+
+		return dow;
+	}
 };

--- a/scripts/3_Game/configmanager.c
+++ b/scripts/3_Game/configmanager.c
@@ -21,8 +21,8 @@ class SpawnSelectConfig
         SpawnLocations.Insert(new ref SpawnLocationObject("West Balota", Vector(4025.159912,6.494447,2620.459961), 1000));
         SpawnLocations.Insert(new ref SpawnLocationObject("Chernogorsk", Vector(6387.430176,9.290138,2699.479980), 1000));
         SpawnLocations.Insert(new ref SpawnLocationObject("Elektrozavodsk", Vector(10322.400391,5.811278,2171.159912), 1000));
-        SpawnTickets.Insert(new ref SpawnTicketObject("BasicSpawnSelect_SpawnTicket", "Bandit", Vector(4111.30, 0, 8912.79), 50, SpawnLocations));
-        SpawnTickets.Insert(new ref SpawnTicketObject("BasicSpawnSelect_SpawnTicket", "Admin",  Vector(4111.30, 0, 8912.79), 50, SpawnLocations));
+        SpawnTickets.Insert(new ref SpawnTicketObject("BasicSpawnSelect_SpawnTicket", "Bandit", Vector(4111.30, 0, 8912.79), 50, SpawnLocations, "1 2 3 4 5 6 7 8", "8 10-10:15 11:20-12 12:30-12:45 13-14"));
+        SpawnTickets.Insert(new ref SpawnTicketObject("BasicSpawnSelect_SpawnTicket", "Admin",  Vector(4111.30, 0, 8912.79), 50, SpawnLocations, "", ""));
 
         SaveSpawnConfig();
     }
@@ -35,9 +35,9 @@ class SpawnSelectConfig
         JsonFileLoader<SpawnSelectConfig>.JsonSaveFile(m_SSConfigPath, this);
     }
 
-    void UpdateTickets(string Classname, string Id, vector UsePosition, float UseRadius, ref array<ref SpawnLocationObject> Spawn)
+    void UpdateTickets(string Classname, string Id, vector UsePosition, float UseRadius, ref array<ref SpawnLocationObject> Spawn, string UseDays, string UseHours)
     {
-        SpawnTickets.Insert(new ref SpawnTicketObject(Classname, Id, UsePosition, UseRadius, Spawn));
+        SpawnTickets.Insert(new ref SpawnTicketObject(Classname, Id, UsePosition, UseRadius, Spawn, UseDays, UseHours));
         JsonFileLoader<SpawnSelectConfig>.JsonSaveFile(m_SSConfigPath, this);
     }
 

--- a/scripts/4_World/entities/itembase/spawnselectticket.c
+++ b/scripts/4_World/entities/itembase/spawnselectticket.c
@@ -42,7 +42,7 @@ class BasicSpawnSelect_SpawnTicket_base extends ItemBase
 				{
 					if(m_ServerConfig.SpawnTickets.Get(i).GetClassName() == this.GetType())
 					{
-						return m_ServerConfig.SpawnTickets.Get(i).IsInUseRange(Position);
+						return m_ServerConfig.SpawnTickets.Get(i).IsInUseRange(Position) && m_ServerConfig.SpawnTickets.Get(i).IsInUseTime();
 					}
 				}
 			}

--- a/scripts/4_World/plugins/pluginbase/pluginspawnselectserver.c
+++ b/scripts/4_World/plugins/pluginbase/pluginspawnselectserver.c
@@ -76,7 +76,7 @@ class PluginBasicSpawnSelectServer extends PluginBase
 
                 ref SpawnTicketObject   m_newTicketObj = data.param1;
                 //string Classname, string Id, vector UsePosition, float UseRadius, ref array<ref SpawnLocationObject> Spawn
-                m_ServerConfig.UpdateTickets(m_newTicketObj.GetClassName(), m_newTicketObj.GetId(), m_newTicketObj.GetUsePostion(), m_newTicketObj.GetUseRadius(), m_newTicketObj.GetLocationsFromTicket());
+                m_ServerConfig.UpdateTickets(m_newTicketObj.GetClassName(), m_newTicketObj.GetId(), m_newTicketObj.GetUsePostion(), m_newTicketObj.GetUseRadius(), m_newTicketObj.GetLocationsFromTicket(), m_newTicketObj.GetUseDaysUTC(), m_newTicketObj.GetUseHoursUTC());
             }
             else
             {

--- a/scripts/4_World/spawnselectmenu.c
+++ b/scripts/4_World/spawnselectmenu.c
@@ -24,6 +24,8 @@ class BasicSpawnSelectMenu extends UIScriptedMenu
     protected EditBoxWidget                         m_AdminTicketUseBoxPosZ;
     protected EditBoxWidget                         m_AdminTicketUseRadius;
     protected EditBoxWidget                         m_AdminTicketClassName;
+    protected EditBoxWidget                         m_AdminTicketUseDays;
+    protected EditBoxWidget                         m_AdminTicketUseHours;
     protected EditBoxWidget                         m_AdminSpawnLocRadiusBox;
     protected CheckBoxWidget                        m_AdminInsertAsSpawnTicketBox;
     protected CheckBoxWidget                        m_AdminUseItemInHandsBox;
@@ -58,6 +60,8 @@ class BasicSpawnSelectMenu extends UIScriptedMenu
             m_AdminTicketUseBoxPosZ         = EditBoxWidget.Cast(layoutRoot.FindAnyWidget("SpawnPosZEdit0"));
             m_AdminTicketUseRadius          = EditBoxWidget.Cast(layoutRoot.FindAnyWidget("UsePosRadiusEdit"));
             m_AdminTicketClassName          = EditBoxWidget.Cast(layoutRoot.FindAnyWidget("UsePosClassName"));
+            m_AdminTicketUseDays            = EditBoxWidget.Cast(layoutRoot.FindAnyWidget("UseDays"));
+            m_AdminTicketUseHours           = EditBoxWidget.Cast(layoutRoot.FindAnyWidget("UseHours"));
             m_AdminSpawnLocRadiusBox        = EditBoxWidget.Cast(layoutRoot.FindAnyWidget("SpawnLocRadiusBox"));
             m_AdminInsertAsSpawnTicketBox   = CheckBoxWidget.Cast(layoutRoot.FindAnyWidget("CheckBoxIsTicket"));
             m_AdminUseItemInHandsBox        = CheckBoxWidget.Cast(layoutRoot.FindAnyWidget("CheckUseItemInHands"));
@@ -332,6 +336,8 @@ class BasicSpawnSelectMenu extends UIScriptedMenu
                         local float SS_UsePosZ = m_AdminTicketUseBoxPosZ.GetText().ToFloat();
                         local float SS_UseRad  = m_AdminTicketUseRadius.GetText().ToFloat();
                         local string SS_SpawnTicketName = m_AdminTicketClassName.GetText();
+                        local string SS_UseDays = m_AdminTicketUseDays.GetText();
+                        local string SS_UseHours = m_AdminTicketUseHours.GetText();
                         vector SS_UseVec = Vector(SS_UsePosX, SS_UsePosY, SS_UsePosZ);
 
                         if(SS_UseRad && SS_SpawnTicketName && SS_UseVec && newSpawnLocObj)
@@ -339,7 +345,7 @@ class BasicSpawnSelectMenu extends UIScriptedMenu
                             //string Classname, string Id, vector UsePosition, float UseRadius, ref array<ref SpawnLocationObject> Spawn
                             ref array<ref SpawnLocationObject> newlocobjarray = new ref array<ref SpawnLocationObject>();
                             newlocobjarray.Insert(newSpawnLocObj);
-                            local ref SpawnTicketObject newSpawnTicketObj = new ref SpawnTicketObject(SS_SpawnTicketName, "NONE", SS_UseVec, SS_UseRad, newlocobjarray);
+                            local ref SpawnTicketObject newSpawnTicketObj = new ref SpawnTicketObject(SS_SpawnTicketName, "NONE", SS_UseVec, SS_UseRad, newlocobjarray, SS_UseDays, SS_UseHours);
                             GetRPCManager().SendRPC("BasicSpawnSelect", "SERVER_ADDNEWSPAWNTICKET", new Param1< ref SpawnTicketObject >( newSpawnTicketObj ), true);
                             player.MessageStatus("[BasicSpawnSelect] -> SpawnTicket sucessfully created!! Please Reload the config now!");
                         }


### PR DESCRIPTION
Here is the feature to allow spawn tickets to be used only within certain days and/or hours.
For "m_UseHoursUTC" it is a list of hours, it can contain minutes, and be a range:
- "" //disabled, can be used at any hour of the day
- "8 9" //can be used at 8:00 (for a duration of 1 minute) and 9:00
- "8 9-10 13:15-14" //can be used at 8:00, between 9 and 10, between 13:15 and 14:00

For "m_UseDaysUTC" it is a list of week days, monday = 1, sunday = 7
- "" //disabled, can be used at any day of the week
- "1" //can only be used on Mondays
- "1 2 3 4 5" cannot be used on the weekend
- "1 2 3 4 5 6 7" can be used at any day (technically same as empty string)