### PR TITLE
Fixed selection not updating map location on the first index

### DIFF
--- a/scripts/4_World/spawnselectmenu.c
+++ b/scripts/4_World/spawnselectmenu.c
@@ -164,7 +164,7 @@ class BasicSpawnSelectMenu extends UIScriptedMenu
     void UpdateMarker()
     {
         local int row_index = m_LocationList.GetSelectedRow();
-        if(row_index)
+        if(row_index >= 0)
         {
             HandleDrawSpotOnMap(row_index);
         }


### PR DESCRIPTION
Hey! Firstly, I want to express that you've done a brilliant job with this mod. While I'm not very knowledgeable about development within Dayz SA, I haven't tested this solution yet because I'm unsure how to. If you would be so kind as to give this a try and update the mod pack, I would truly appreciate it. Alternatively, if you could guide me on how to test this mod locally, that would also be incredibly helpful.

## Current behaviour
When the first spawn option is selected it doesn't update the map location for the user. 

## Expected behaviour
Users should be able to see clearly their selected spawn option on the map.

## How to reproduce?
https://vimeo.com/856010558/2bafe7dcaa?share=copy